### PR TITLE
Extend functionality to all censored words

### DIFF
--- a/betterchatfilter/betterchatfilter.lua
+++ b/betterchatfilter/betterchatfilter.lua
@@ -6,51 +6,18 @@ BETTERCHATFILTER = _G["ADDONS"]["BETTERCHATFILTER"];
 function BETTERCHATFILTER_ON_INIT(addon, frame)
 	BETTERCHATFILTER.addon = addon;
 	BETTERCHATFILTER.frame = frame;
-	
-	BETTERCHATFILTER.init();
-end
-
-BETTERCHATFILTER.filteredWords = {
-	{bad = "([aA])([nN])([aA])([lL])"									, good = "%1%2*%4"},
-	{bad = "([aA])([sS])([sS])"											, good = "*%2%3"},
-	{bad = "([bB])([dD])([sS])([mM])"									, good = "%1%2.%3%4"},
-	{bad = "([bB])([uU])([tT])([tT])"									, good = "%1*%3%4"},
-	{bad = "([cC])([oO])([cC])([kK])"									, good = "%1*%3%4"},
-	{bad = "([cC])([uU])([mM])"											, good = "%1*%3"},
-	{bad = "([dD])([aA])([mM])([nN])"									, good = "%1*%3%4"},
-	{bad = "([eE])([sS])([cC])([oO])([rR])([tT])"						, good = "%1%2%3*%5%6"},
-	{bad = "([fF])([uU])([cC])([kK])"									, good = "%1*%3%4"},
-	{bad = "([gG])([aA])([yY])"											, good = "*%2%3"},
-	{bad = "([lL])([eE])([sS])([bB])([iI])([aA])([nN])"					, good = "%1%2%3%4%5*%7"},
-	{bad = "([lL])([oO])([lL])([iI])([tT])([aA])"						, good = "%1*%3%4%5%6"},
-	{bad = "([nN])([iI])([pP])([pP])([lL])([eE])"						, good = "%1*%3%4%5%6"},
-	{bad = "([pP])([aA])([nN])([tT])([iI])([eE])([sS])"					, good = "%1*%3%4%5%6%7"},
-	{bad = "([pP])([aA])([nN])([tT])([yY])"								, good = "%1*%3%4%5"},
-	{bad = "([sS])([eE])([mM])([eE])([nN])"								, good = "%1*%3%4%5"},
-	{bad = "([sS])([eE])([xX])"											, good = "%1*%3"},
-	{bad = "([sS])([hH])([iI])([bB])([aA])([rR])([iI])"					, good = "%1%2*%4%5%6%7"},
-	{bad = "([sS])([hH])([iI])([tT])"									, good = "%1%2*%4"},
-	{bad = "([sS])([pP])([iI])([cC])"									, good = "%1%2*%4"},
-	{bad = "([tT])([iI])([tT])"											, good = "%1*%3"},
-};
-
--- ===========================================================
-
-function BETTERCHATFILTER.init()
+		
 	if (BETTERCHATFILTER.isLoaded ~= true) then
 		CHAT_SYSTEM("Better Chat Filter loaded!");
 		
 		BETTERCHATFILTER.isLoaded = true;
 	end
 	
-	local g = _G["ADDONS"]["BETTERCHATFILTER"];
-		
-	g.addon:RegisterMsg("GAME_START_3SEC", "BETTERCHATFILTER_3SEC");
+	addon:RegisterMsg("GAME_START_3SEC", "BETTERCHATFILTER_3SEC");
 end
 
+
 function BETTERCHATFILTER_3SEC()
-	
-	
 	local chatframe = ui.GetFrame("chat");
 	local mainchat = GET_CHILD(chatframe, "mainchat", "ui::CEditControl");
 	
@@ -58,8 +25,9 @@ function BETTERCHATFILTER_3SEC()
 end
 
 function BETTERCHATFILTER_TYPING_IN_CHAT(parent, ctrl)	
-	parent:CancelReserveScript("BETTERCHATFILTER_SEARCH_FOR_FILTERED_WORDS");
-	parent:ReserveScript("BETTERCHATFILTER_SEARCH_FOR_FILTERED_WORDS", 0.1, 1);
+	BETTERCHATFILTER_SEARCH_FOR_FILTERED_WORDS();
+	--parent:CancelReserveScript("BETTERCHATFILTER_SEARCH_FOR_FILTERED_WORDS");
+	--parent:ReserveScript("BETTERCHATFILTER_SEARCH_FOR_FILTERED_WORDS", 0.1, 1);
 end
 
 function BETTERCHATFILTER_SEARCH_FOR_FILTERED_WORDS()
@@ -67,24 +35,90 @@ function BETTERCHATFILTER_SEARCH_FOR_FILTERED_WORDS()
 	local mainchat = GET_CHILD(chatframe, "mainchat", "ui::CEditControl");
 	
 	local chattext = mainchat:GetText();
+	local badword = IsBadString(chattext);
 	
-	for i = 1, #BETTERCHATFILTER.filteredWords do
-		local fwordobj = BETTERCHATFILTER.filteredWords[i];
-		
-		local status, err = pcall(function() chattext = string.gsub(chattext, fwordobj.bad, fwordobj.good) end);
-		if (status == true) then
-			--CHAT_SYSTEM("Everything good");
-			mainchat:SetText(chattext);
+	if badword ~= nil then
+		badword = badword:sub(1,9); -- limit to 9 characters because of pattern referencing limits ( %1-9 )
+
+		local escaped = BETTERCHATFILTER.patternEscape(badword);
+		local capture = BETTERCHATFILTER.caseInsensitiveCapture(escaped);
+		local goodword = BETTERCHATFILTER.getGood(badword);
+
+		chattext = chattext:gsub(capture, goodword)
+		mainchat:SetText(chattext);
+	end
+end
+
+BETTERCHATFILTER.censorChar = '*';
+
+function BETTERCHATFILTER.getGood(str)
+	local _str = BETTERCHATFILTER.patternEscape(str);
+	if _str:match("%%") or _str:match("\\") or _str:match("%(") then
+		return BETTERCHATFILTER.censorChar:rep(#str);
+	end
+
+	local trailingSpace = '';
+
+	if str:match("[^\128-\191][\128-\191]*$") == ' ' then 
+		trailingSpace = ' ';
+		str = str:sub(1, #str-1);
+	end
+
+	local multi = #str-6;
+	if multi < 1 then multi = 1 end;
+
+	local pos = math.floor(#str/2) - math.floor(multi/2);
+
+	_str = '';
+	for i=1, #str do
+		if i <= pos or i > pos+multi then
+			_str = _str .. '%' .. i;
 		else
-			CHAT_SYSTEM("Error: " .. err);
-			CHAT_SYSTEM("Bad word: " .. fwordobj.bad);
+			_str = _str .. BETTERCHATFILTER.censorChar;
 		end
 	end
-	
-	--CHAT_SYSTEM(chattext);
+
+	_str = _str .. trailingSpace;
+
+	return _str;
+end
+
+function BETTERCHATFILTER.caseInsensitiveCapture(pattern)
+
+	-- find an optional '%' (group 1) followed by any character (group 2)
+	local p = pattern:gsub("(%%?)(.)", function(percent, letter)
+		if percent ~= "" or not letter:match("%a") then
+			-- if the '%' matched, or `letter` is not a letter, return "as is"
+			return '[' .. percent .. letter .. ']';
+		else
+			-- else, return a case-insensitive character class of the matched letter
+			return string.format("[%s%s]", letter:lower(), letter:upper())
+		end
+	end)
+	return p:gsub("(%[.-])", "(%1)")
+end
+
+BETTERCHATFILTER.escapeMatches =
+{
+	["^"] = "%^";
+	["$"] = "%$";
+	["("] = "%(";
+	[")"] = "%)";
+	["%"] = "%%";
+	["."] = "%.";
+	["["] = "%[";
+	["]"] = "%]";
+	["*"] = "%*";
+	["+"] = "%+";
+	["-"] = "%-";
+	["?"] = "%?";
+}
+
+function BETTERCHATFILTER.patternEscape(s)
+	return (s:gsub(".", BETTERCHATFILTER.escapeMatches))
 end
 
 -- FOR TEST ONLY
 --if (DEVLOADER.isLoaded == true) then
 --	BETTERCHATFILTER_3SEC();
---end
+--end 


### PR DESCRIPTION
Also refactor and hook `ui.Chat`, this way if the message is sent before the delay is up on typing in chat, the message will still be filtered. Although the delay is so short that the message is filtered after each keystroke at the moment anyway.

Removing the hook on ui.Chat as well as the delay would allow the code to function still, or removing the hook on each keystroke and leaving only the ui.Chat hook would do the same, but the censored text would only appear upon being sent.
